### PR TITLE
Fix iOS screen wake by enabling NoSleep immediately on mount

### DIFF
--- a/src/components/GameView.vue
+++ b/src/components/GameView.vue
@@ -19,14 +19,19 @@ const menuOpen = ref(false)
 // Keep screen awake while playing (Wake Lock API on Android/desktop, video hack on iOS)
 const noSleep = new NoSleep()
 function enableNoSleep() {
-  noSleep.enable()
+  noSleep.enable().catch(() => {})
   document.removeEventListener('touchstart', enableNoSleep)
   document.removeEventListener('click', enableNoSleep)
 }
-onMounted(() => {
-  // NoSleep requires a user gesture on iOS before it can play video
-  document.addEventListener('touchstart', enableNoSleep, { once: true })
-  document.addEventListener('click', enableNoSleep, { once: true })
+onMounted(async () => {
+  // Try immediately — works on iOS 16.4+/Android/desktop via Wake Lock API (no gesture needed).
+  // Falls back to gesture listeners for older iOS where the video path requires user interaction.
+  try {
+    await noSleep.enable()
+  } catch {
+    document.addEventListener('touchstart', enableNoSleep, { once: true })
+    document.addEventListener('click', enableNoSleep, { once: true })
+  }
 })
 onUnmounted(() => {
   noSleep.disable()


### PR DESCRIPTION
Try noSleep.enable() directly in onMounted — Wake Lock API (iOS 16.4+,
Android, desktop) doesn't require a user gesture, so the screen was
unnecessarily staying unlocked until the first tap. Fall back to
touchstart/click listeners for older iOS where the video path needs
a gesture.

https://claude.ai/code/session_01XTCkcrVzafvYuNCzETE7tR